### PR TITLE
Builds status STOPPED is also acceptable

### DIFF
--- a/scripts/out
+++ b/scripts/out
@@ -31,8 +31,8 @@ else:
 
 
 # The build status can only be one of three things
-if build_status not in ['INPROGRESS', 'SUCCESSFUL', 'FAILED']:
-    print_error("Invalid build status, must be: INPROGRESS, SUCCESSFUL, or FAILED")
+if build_status not in ['INPROGRESS', 'SUCCESSFUL', 'FAILED', 'STOPPED']:
+    print_error("Invalid build status, must be: INPROGRESS, SUCCESSFUL, FAILED or STOPPED")
     exit(1)
 
 commit_hash = ''


### PR DESCRIPTION
According to [Bitbucket API reference](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/statuses/build) the build can have the status of STOPPED, I checked the change with Bitbucket cloud and it's working.