### PR TITLE
Authenticate with Bitbucket Server via Token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update --no-progress && \
         py3-pip \
         git \
         mercurial && \
-    pip3 install --upgrade pip && \
-    pip3 install 'requests>=2.8.1'
+    pip3 install --break-system-packages 'requests>=2.8.1'
 
 ADD scripts /opt/resource

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ HTTP 401 Unauthorized - Are your bitbucket credentials correct?
 
 ### `Bitbucket Server` Driver
 * `endpoint` - *Required*. URL to a Bitbucket Server instance.
-* `username` - *Required*. Login name of someone with rights to the repository which's build status should be updated.
-* `password` - *Required*. Password associated with that login.
+* `username` - *Required (if token is not set)*. Login name of someone with rights to the repository which's build status should be updated.
+* `password` - *Required (if token is not set)*. Password associated with that login.
+* `token` - *Optional*. Token to use with bearer-token auth. If set username and password are not required anymore.
 * `verify_ssl` - *Optional.* *Default: `true`.* When `false`, ignore any HTTPS connection errors if generated. Useful if on an internal network.
 * `bitbucket_url` - *Required*. **DEPRECATED. Use `endpoint` instead.** URL of the bitbucket instance, including a trailing slash.
 * `bitbucket_username` - *Required*. **DEPRECATED. Use `username` instead.** Login username of someone with rights to the repository being updated.

--- a/scripts/bitbucket/bitbucket_server.py
+++ b/scripts/bitbucket/bitbucket_server.py
@@ -8,16 +8,19 @@ class BitbucketServerDriver(BitbucketDriver, ConcourseResource):
     def __init__(self, config, debug):
         ConcourseResource.__init__(self, config)
         self.debug = debug
+        self.token = config['source'].get('token', '')
         self.username = config['source'].get('username', config['source'].get('bitbucket_username', ''))
         self.password = config['source'].get('password', config['source'].get('bitbucket_password', ''))
         self.endpoint = config['source'].get('endpoint', config['source'].get('bitbucket_url', ''))
         self.verify_ssl = config['source'].get('verify_ssl', False)
 
-        if self.username == '':
-            raise MissingSourceException('username')
 
-        if self.password == '':
-            raise MissingSourceException('password')
+        if self.token == '':
+            if self.username == '':
+                raise MissingSourceException('username')
+
+            if self.password == '':
+                raise MissingSourceException('password')
 
         if self.endpoint == '':
             raise MissingSourceException('endpoint')
@@ -36,10 +39,14 @@ class BitbucketServerDriver(BitbucketDriver, ConcourseResource):
         return url
 
     def get_request_options(self):
-        return {
-            'auth': HTTPBasicAuth(self.username, self.password),
+        options = {
             'verify': self.verify_ssl
         }
+        if self.token != '':
+            options["headers"] = {'Authorization': 'Bearer ' + self.token}
+        else:
+            options["auth"] = HTTPBasicAuth(self.username, self.password)
+        return options
 
     def get_valid_response_status(self):
         return [204]


### PR DESCRIPTION
Hi,

the guys running the bitbucket server at my company decided to completely disable username+password authentication.
The only remaining supported authentication method for the Bitbucket-API is therefore HTTP-Bearer-Tokens.

Sadly that makes it impossible to use this very neat little resource, as it does not support token authentication.

However I figured it would not be too hard to add this functionality so I went ahead and did exactly that.
It would be great if this functionality would find it's way into this repo, so there doesn't have to be yet another fork.